### PR TITLE
Refactor: fix bugs, remove bare excepts, clean up writer/scraper code

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ def main():
             if in_dict:
                 try:
                     has_pane = window.get_by_id(url_to_pane[url]) is not None
-                except:
+                except Exception:
                     has_pane = True
             else:
                 has_pane = False
@@ -77,10 +77,12 @@ def main():
                 # we had a pane for this, livestream is still up, but pane is dead
                 print(f"{now()} {url} dropped, restarting")
                 log.write(f"{now()} {url} dropped, restarting\n")
+                log.flush()
 
             else:
                 print(f"{now()} {url} started")
                 log.write(f"{now()} {url} started\n")
+                log.flush()
 
             id = window.split_window(shell=f"python3 {os.path.dirname(os.path.realpath(__file__))}/scrape.py {url} {url}").id
             session.list_windows()[0].select_layout('tiled')

--- a/modules/indexer/holodex.py
+++ b/modules/indexer/holodex.py
@@ -11,7 +11,7 @@ class HolodexIndexer(Indexer):
 
         try:
             streams = requests.get("https://holodex.net/api/v2/live?type=placeholder%2Cstream&org=Hololive", headers={"X-APIKEY": apikey}).json()
-        except:
+        except Exception:
             return []
 
         ret = []

--- a/modules/indexer/nijidex.py
+++ b/modules/indexer/nijidex.py
@@ -5,13 +5,13 @@ from .base import Indexer
 
 class NijisanjiIndexer(Indexer):
     def get_streams(self):
-        if not hasattr(self.configs, 'apikey'):
+        if not hasattr(self.configs, 'holodex_apikey'):
             return []
         apikey = self.configs.holodex_apikey
 
         try:
             streams = requests.get("https://holodex.net/api/v2/live?type=placeholder%2Cstream&org=Nijisanji", headers={"X-APIKEY": apikey}).json()
-        except:
+        except Exception:
             return []
 
         ret = []

--- a/modules/writer/base.py
+++ b/modules/writer/base.py
@@ -5,13 +5,12 @@ from modules.logger.base import createLogger
 
 class Writer:
     def __init__(self, c: config.ConfigHandler, video_id: str):
+        self.configs = c
+        self.video_id = video_id
+        self.logger = createLogger(logging.INFO, video_id, __name__)
+
         if not self.validate_configs(c):
             raise Exception()
-        self.configs = c
-
-        self.video_id = video_id
-
-        self.logger = createLogger(logging.INFO, video_id, __name__)
 
     def validate_configs(self, config: config.ConfigHandler):
         return True

--- a/modules/writer/database.py
+++ b/modules/writer/database.py
@@ -43,11 +43,7 @@ class DatabaseWriter(Writer):
 
     @staticmethod
     def check_config_enabled(config: config.ConfigHandler):
-        if not hasattr(config, 'write_to_db'):
-            self.logger.warning("config has no attribute for DatabaseWriter")
-            return False
-        
-        return config.write_to_db
+        return hasattr(config, 'write_to_db') and config.write_to_db
 
     def generate_batch(self):
         self.next_batch = randint(30,100)
@@ -77,8 +73,7 @@ class DatabaseWriter(Writer):
             self.logger.error(str(e))
 
     def post(self):
-        self.logger.info(f"posting {self.next_batch} chats...")
-        print(f"posting {self.next_batch} chats...")
+        self.logger.info(f"posting {len(self.chat_buffer)} chats...")
         try:
             query = r'INSERT INTO ' + self.db_table + '_' + self.shard + r' VALUES (%s, %s, %s, %s, %s, %s, %s) ON DUPLICATE KEY UPDATE source = CONCAT(source, ' + f"' {self.hostname}\')"
             self.cursor.executemany(query, self.chat_buffer)
@@ -86,7 +81,6 @@ class DatabaseWriter(Writer):
         except Exception as e:
             self.logger.error(str(e))
         self.logger.info("done")
-        print("done")
 
     def finalise(self):
         self.post()

--- a/modules/writer/filesystem.py
+++ b/modules/writer/filesystem.py
@@ -15,22 +15,18 @@ class FilesystemWriter(Writer):
         
     def validate_configs(self, c: config.ConfigHandler):
         if not hasattr(c, 'local_path'):
-            self.logging.error("local_path missing")
+            self.logger.error("local_path missing")
             return False
 
         if not os.path.exists(c.local_path):
-            self.logging.error("local_path not a valid directory")
+            self.logger.error("local_path not a valid directory")
             return False
 
         return True
 
     @staticmethod
     def check_config_enabled(c: config.ConfigHandler):
-        if not hasattr(c, 'write_to_local'):
-            self.logging.warning('config has no attribute for FilesystemWriter')
-            return False
-        
-        return c.write_to_local
+        return hasattr(c, 'write_to_local') and c.write_to_local
 
     def process(self, chat):
         self.file.write(f"{self.video_id} {chat.id.replace('%3D', '=')} {chat.datetime} {chat.message}\n")
@@ -46,4 +42,5 @@ class FilesystemWriter(Writer):
                 json.dump(stream, f, indent=4, ensure_ascii=False)
 
     def finalise(self):
-        self.file.close()
+        if self.video_id:
+            self.file.close()

--- a/scrape.py
+++ b/scrape.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import logging
-import os
 import pytchat
 import time
 import sys
@@ -19,10 +18,6 @@ class Scraper:
         self.config = config.get_configs()
         self.logger = createLogger(logging.INFO, video_id, "holoscrape")
 
-        log_path = os.path.join(self.config.log_path, video_id + ".log")
-        with open(log_path, 'w+') as f:
-            pass
-
         self.writers = []
 
         if DatabaseWriter.check_config_enabled(self.config):
@@ -31,9 +26,9 @@ class Scraper:
         if FilesystemWriter.check_config_enabled(self.config):
             self.writers.append(FilesystemWriter(self.config, video_id))
 
-        if len(self.writers) <= 0:
+        if not self.writers:
             self.logger.error("no writers configured")
-            quit()
+            sys.exit(1)
     
     def get_video(self):
         self.video = None
@@ -45,10 +40,10 @@ class Scraper:
                 continue
             except Exception as e:
                 self.logger.error(str(e))
-                quit()
+                sys.exit(1)
         if self.video is None:
             self.logger.error("can't retrieve video")
-            quit()
+            sys.exit(1)
 
     def run(self):
         self.get_video()


### PR DESCRIPTION
- Fix NijisanjiIndexer hasattr check (apikey -> holodex_apikey), making
  Nijisanji stream fetching actually work when an API key is configured
- Replace all bare `except:` clauses with `except Exception` in indexers
  and main.py to avoid silently swallowing unexpected errors
- Reorder Writer base __init__ so self.logger is set before validate_configs
  is called, fixing AttributeError in DatabaseWriter.validate_configs
- Fix DatabaseWriter.check_config_enabled and FilesystemWriter.check_config_enabled:
  both were static methods incorrectly referencing `self`; simplified to
  one-liner boolean expressions
- Fix FilesystemWriter.validate_configs: self.logging -> self.logger
- Guard FilesystemWriter.finalise() against video_id=None (no file opened)
- Remove duplicate print() calls from DatabaseWriter.post(); use logger only;
  also log actual buffer length instead of stale next_batch value
- Replace quit() with sys.exit(1) in scrape.py (quit() is for interactive use)
- Remove redundant log file creation in Scraper.__init__ (BaseLogger handles it)
- Remove unused `os` import from scrape.py
- Flush main.py log file after each write so entries appear immediately

https://claude.ai/code/session_01BpTvhXXCBwKzbuWgVvzwuP